### PR TITLE
Revert "Revisiting enum values for community status"

### DIFF
--- a/json-schemas/1.0.x/community.json
+++ b/json-schemas/1.0.x/community.json
@@ -31,7 +31,7 @@
 		"status": {
 			"title": "_id(s) of the current community status(es)",
 			"type": "string",
-			"enum": [ "inactive","active","unknown","coming_soon" ]
+			"enum": [ "abandoned","active","unknown" ]
 		},
 		"description": {
 			"title": "Long community name or description",


### PR DESCRIPTION
These changes should be applied on 2.0.x branch, over 2.0.x model.

Reverts inab/benchmarking-data-model#132